### PR TITLE
Improve README and async message handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# meshtastic-llm
+# Meshtastic LLM Bot
+
+This repository contains a small Python script that bridges a local language model running in LM Studio with a Meshtastic radio. It listens for direct messages and replies with completions from the selected model.
+
+## Requirements
+
+- Python 3.9+
+- A Meshtastic device connected via USB
+- LM Studio running an API server (default: `http://localhost:1234/v1`)
+
+Install Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. Start LM Studio and load the desired model. The script defaults to `mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF`, but you can change this in `meshtastic_llm_bot.py`.
+2. Connect your Meshtastic radio.
+3. Run the bot:
+
+```bash
+python meshtastic_llm_bot.py
+```
+
+The program will wait for direct messages on the radio and send back the LLM's response in appropriately sized chunks.
+
+### Customizing
+
+- Update `openai.api_base` if your LM Studio server is running on a different host or port.
+- Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+meshtastic
+openai
+pypubsub


### PR DESCRIPTION
## Summary
- expand README with setup and usage instructions
- add simple requirements.txt for dependencies
- refactor bot to process messages in background threads

## Testing
- `python3 -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6886792703c08328a4cb8c924ab73986