### PR TITLE
Add concise responses and chunk numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 python meshtastic_llm_bot.py
 ```
 
-The program will wait for direct messages on the radio and send back the LLM's response in appropriately sized chunks.
+The program will wait for direct messages on the radio and send back the LLM's response in numbered chunks for easy ordering.
 
 ### Customizing
 


### PR DESCRIPTION
## Summary
- make system prompt encourage concise answers
- break outgoing messages into numbered chunks
- note in README that responses come in numbered chunks

## Testing
- `python -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68868282dac4832884c1a0c864abf505