### PR TITLE
Show menu on first contact or help

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The program will wait for direct messages on the radio and send back the LLM's r
 - `weather [location]` – show the current weather using the wttr.in service. If no location is given, a default location is used.
 - Any other text will be answered by the language model.
 
-Every response from the bot begins with this command list for quick reference.
+The command menu is shown only on your first message to the bot or whenever you send `help`.
 
 ### Customizing
 


### PR DESCRIPTION
## Summary
- display menu only the first time a peer interacts or when `help` is sent
- update README to reflect menu behaviour

## Testing
- `python -m py_compile meshtastic_llm_bot.py`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688687e31198832897cf9be362c06a8a