### PR TITLE
Improve menu and response separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The program will wait for direct messages on the radio and send back the LLM's r
 - Any other text will be answered by the language model.
 
 The command menu is shown only on your first message to the bot or whenever you send `help`.
+When it is displayed automatically, the menu is sent as its own message before the bot replies to your request.
 
 ### Customizing
 

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -89,16 +89,16 @@ def handle_message(peer: int, text: str, interface):
             menu_shown.add(peer)
             return
 
-        prefix = ""
         if peer not in menu_shown:
-            prefix = MENU + "\n"
+            print(f"[OUT] To {peer}: {MENU}")
+            send_chunked_text(MENU, peer, interface)
             menu_shown.add(peer)
 
         if lower.startswith("weather"):
             parts = text.split(maxsplit=1)
             location = parts[1] if len(parts) > 1 else DEFAULT_LOCATION
             weather = get_weather(location)
-            reply_text = prefix + weather
+            reply_text = weather
             print(f"[OUT] To {peer}: {reply_text}")
             send_chunked_text(reply_text, peer, interface)
             return
@@ -115,7 +115,6 @@ def handle_message(peer: int, text: str, interface):
 
         record_message(peer, "assistant", reply_text)
 
-        reply_text = prefix + reply_text
         print(f"[OUT] To {peer}: {reply_text}")
 
         send_chunked_text(reply_text, peer, interface)


### PR DESCRIPTION
## Summary
- display the command menu as a standalone message
- clarify menu behavior in README

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68868a384b988328b8694cebc2812173