### PR TITLE
Improve bot resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ When it is displayed automatically, the menu is sent as its own message before t
 ### Customizing
 
 - Update `openai.api_base` if your LM Studio server is running on a different host or port.
-- Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
+ - Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
+ - `MAX_HISTORY_LEN` controls how many messages per peer are kept in memory.
+ - `MAX_WORKERS` limits how many threads can handle messages concurrently.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add limits on conversation history
- use a threadpool and lock access to the menu
- clean up executor on shutdown
- document new options

## Testing
- `python -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6886962e6f488328af2195d6099420cd