### PR TITLE
Add Emerald channel and requests-based LM Studio integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meshtastic LLM Bot
 
-This repository contains a small Python script that bridges a local language model running in LM Studio with a Meshtastic radio. It listens for direct messages and replies with completions from the selected model.
+This repository contains a small Python script that bridges a local language model running in LM Studio with a Meshtastic radio. It listens for direct messages and messages on the `Emerald` channel, replying with completions from the selected model and occasionally posting a joke to the channel.
 
 ## Requirements
 
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 python meshtastic_llm_bot.py
 ```
 
-The program will wait for direct messages on the radio and send back the LLM's response in numbered chunks for easy ordering.
+The program will wait for direct messages and messages on the `Emerald` channel, sending back the LLM's response in numbered chunks for easy ordering. Every so often it also broadcasts a random joke to `Emerald` for users to reply to.
 
 ### Commands
 
@@ -37,7 +37,7 @@ When it is displayed automatically, the menu is sent as its own message before t
 
 ### Customizing
 
-- Update `openai.api_base` if your LM Studio server is running on a different host or port.
+- Update `API_BASE` if your LM Studio server is running on a different host or port.
  - Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
  - `MAX_HISTORY_LEN` controls how many messages per peer are kept in memory.
  - `MAX_WORKERS` limits how many threads can handle messages concurrently.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 meshtastic
-openai
 pypubsub
 requests


### PR DESCRIPTION
## Summary
- listen and respond on the `Emerald` channel in addition to DMs
- query LM Studio using `requests` instead of the OpenAI client and post periodic jokes to `Emerald`
- document new channel behavior and drop the `openai` dependency

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688d0d39f6908328be08c008ffeb6485