### PR TITLE
Add explicit Emerald channel index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meshtastic LLM Bot
 
-This repository contains a small Python script that bridges a local language model running in LM Studio with a Meshtastic radio. It listens for direct messages and messages on the `Emerald` channel, replying with completions from the selected model and occasionally posting a hacker-themed note to the channel.
+This repository contains a small Python script that bridges a local language model running in LM Studio with a Meshtastic radio. It listens for direct messages and messages on channel 3 (the `Emerald` channel), replying with completions from the selected model and occasionally posting a hacker-themed note to the channel.
 
 ## Requirements
 
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 python meshtastic_llm_bot.py
 ```
 
-The program will wait for direct messages and messages on the `Emerald` channel, sending back the LLM's response in numbered chunks for easy ordering. Every so often it also broadcasts a random hacker message about EmeraldCon for users to reply to.
+The program will wait for direct messages and messages on channel 3 (`Emerald`), sending back the LLM's response in numbered chunks for easy ordering. Every so often it also broadcasts a random hacker message about EmeraldCon for users to reply to.
 
 ### Commands
 
@@ -37,7 +37,8 @@ When it is displayed automatically, the menu is sent as its own message before t
 
 ### Customizing
 
-- Update `API_BASE` if your LM Studio server is running on a different host or port.
+ - Update `API_BASE` if your LM Studio server is running on a different host or port.
+ - Change `EMERALD_CHANNEL_INDEX` if the Emerald channel uses a different slot.
  - Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
  - `MAX_HISTORY_LEN` controls how many messages per peer are kept in memory.
  - `MAX_WORKERS` limits how many threads can handle messages concurrently.

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -25,7 +25,9 @@ CHUNK_DELAY = 0.2
 MAX_HISTORY_LEN = 20
 # Maximum number of worker threads
 MAX_WORKERS = 4
-# Channel to listen and occasionally post hacker messages on
+# Channel index to listen and occasionally post hacker messages on
+EMERALD_CHANNEL_INDEX = 3
+# Human-readable name for the channel
 EMERALD_CHANNEL_NAME = "Emerald"
 # How often to post a hacker message to the Emerald channel (seconds)
 HACKER_INTERVAL = 3600
@@ -201,18 +203,6 @@ def on_receive(packet, interface):
 # Subscribe to receive events
 pub.subscribe(on_receive, "meshtastic.receive")
 
-
-def find_channel_index(interface, name: str):
-    try:
-        for i, ch in enumerate(interface.radioConfig.channels):
-            ch_name = getattr(ch.settings, "name", "")
-            if ch_name and ch_name.lower() == name.lower():
-                return i
-    except Exception:
-        pass
-    return None
-
-
 def hacker_sender(interface):
     while True:
         time.sleep(HACKER_INTERVAL)
@@ -224,11 +214,13 @@ def hacker_sender(interface):
 def main():
     global emerald_channel
     interface = SerialInterface()  # Connect to your first Meshtastic device
-    emerald_channel = find_channel_index(interface, EMERALD_CHANNEL_NAME)
+    emerald_channel = EMERALD_CHANNEL_INDEX
 
     threading.Thread(target=hacker_sender, args=(interface,), daemon=True).start()
 
-    print("Meshtastic ↔️ LLM bot running. Listening for DMs and Emerald channel…")
+    print(
+        f"Meshtastic ↔️ LLM bot running. Listening for DMs and channel {EMERALD_CHANNEL_INDEX} ({EMERALD_CHANNEL_NAME})…"
+    )
     try:
         while True:
             time.sleep(1)


### PR DESCRIPTION
## Summary
- reference channel 3 explicitly for Emerald operations
- document Emerald channel index in README and config

## Testing
- `python -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_688d14449a788328a43003b5b2f53cb5