### PR TITLE
Fix channel chunking reliability

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -93,7 +93,9 @@ def send_chunked_text(text: str, target: int, interface, channel: bool = False):
     chunks = split_into_chunks(text, size)
     for chunk in chunks:
         if channel:
-            interface.sendText(chunk, channelIndex=target)
+            # Broadcast messages don't receive ACKs, so disable them to prevent
+            # the send queue from stalling and dropping later chunks.
+            interface.sendText(chunk, channelIndex=target, wantAck=False)
         else:
             interface.sendText(chunk, target)
         time.sleep(CHUNK_DELAY)


### PR DESCRIPTION
## Summary
- Disable ACKs when sending chunked channel messages to prevent later chunks from stalling

## Testing
- `python -m py_compile meshtastic_llm_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d2283985c83289a29f17822f274da