### PR TITLE
Wait for ack between chunked messages

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -120,6 +120,9 @@ def send_chunked_text(text: str, target: int, interface, channel: bool = False):
             interface.sendText(payload, channelIndex=target, wantAck=False)
         else:
             interface.sendText(payload, target, wantAck=True)
+            # Wait for the device to acknowledge each chunk before
+            # sending the next to avoid losing intermediate chunks.
+            interface.waitForAckNak()
         time.sleep(CHUNK_DELAY)
 
 


### PR DESCRIPTION
## Summary
- ensure each DM chunk waits for ACK before sending next

## Testing
- `python -m py_compile meshtastic_llm_bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d274b27b48328b644a1908caff6b1