### PR TITLE
Handle ACK timeouts while sending chunks

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -123,8 +123,13 @@ def send_chunked_text(text: str, target: int, interface, channel: bool = False):
         else:
             interface.sendText(payload, target, wantAck=True)
             # Wait for the device to acknowledge each chunk before
-            # sending the next to avoid losing intermediate chunks.
-            interface.waitForAckNak()
+            # sending the next to avoid losing intermediate chunks. If the
+            # ACK doesn't arrive in time, log a warning but continue sending
+            # remaining chunks so the message isn't truncated.
+            try:
+                interface.waitForAckNak()
+            except Exception as e:  # pragma: no cover - best effort logging
+                print(f"Warning: no ACK for chunk {i}/{total}: {e}")
         time.sleep(CHUNK_DELAY)
 
 


### PR DESCRIPTION
## Summary
- prevent long messages from truncating when ACKs time out by catching exceptions around `waitForAckNak`

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688d29127a248328ab472d9f6b3bce74