### PR TITLE
Fix listener signature for on_receive

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -185,8 +185,10 @@ def handle_message(target: int, text: str, iface, is_channel=False):
     send_chunked_text(reply, target, iface, channel=is_channel)
 
 
-def on_receive(pkt, iface):
+def on_receive(packet=None, interface=None, **kwargs):
     try:
+        pkt = packet or {}
+        iface = interface
         channel = pkt.get("channel") or pkt.get("channelIndex") or pkt.get("channel_index")
         to = pkt.get("to")
         text = pkt.get("decoded", {}).get("text", "").strip()


### PR DESCRIPTION
## Summary
- Ensure on_receive accepts keyword args used by Meshtastic pubsub

## Testing
- `python -m py_compile meshtastic_llm_bot.py`
- `python - <<'PY'
from types import SimpleNamespace
from meshtastic_llm_bot import on_receive

class DummyIface:
    def __init__(self):
        self.myInfo = SimpleNamespace(my_node_num=1)
    def sendText(self, *args, **kwargs):
        print('sendText', args, kwargs)
    def waitForAckNak(self):
        pass

pkt = {
    'channel': 3,
    'to': 1,
    'from': 2,
    'decoded': {'text': 'Hello Smudge'}
}

on_receive(packet=pkt, interface=DummyIface())
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_688d3da070a88328b20fe575c96f417a