### PR TITLE
Ensure channel detection handles index 0

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -204,7 +204,11 @@ def on_receive(packet=None, interface=None, **kwargs):
     try:
         pkt = packet or {}
         iface = interface
-        channel = pkt.get("channel") or pkt.get("channelIndex") or pkt.get("channel_index")
+        channel = pkt.get("channel")
+        if channel is None:
+            channel = pkt.get("channelIndex")
+        if channel is None:
+            channel = pkt.get("channel_index")
         to = pkt.get("to")
         text = pkt.get("decoded", {}).get("text", "").strip()
         if not text:


### PR DESCRIPTION
## Summary
- fix channel selection so channel 0 is recognized when listening on all channels

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9a3456f08328a01ff70cee4399a2