### PR TITLE
Fix channel parsing for channel 0 handling

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -204,7 +204,11 @@ def on_receive(packet=None, interface=None, **kwargs):
     try:
         pkt = packet or {}
         iface = interface
-        channel = pkt.get("channel")
+        chan_info = pkt.get("channel")
+        if isinstance(chan_info, dict):
+            channel = chan_info.get("index")
+        else:
+            channel = chan_info
         if channel is None:
             channel = pkt.get("channelIndex")
         if channel is None:


### PR DESCRIPTION
## Summary
- handle Meshtastic packets where `channel` is a dict and extract its `index`
- ensures bot responds correctly on all channels including channel 0

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9bb173d08328b3990d56f9e930ca