### PR TITLE
Coerce channel id to int for channel responses

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -213,6 +213,12 @@ def on_receive(packet=None, interface=None, **kwargs):
             channel = pkt.get("channelIndex")
         if channel is None:
             channel = pkt.get("channel_index")
+
+        # ensure channel is an int for set membership
+        try:
+            channel = int(channel)
+        except (TypeError, ValueError):
+            channel = None
         to = pkt.get("to")
         text = pkt.get("decoded", {}).get("text", "").strip()
         if not text:


### PR DESCRIPTION
## Summary
- Ensure received channel info is converted to `int` before evaluating response eligibility

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9d568cf4832880d313e055caf4c2