### PR TITLE
Use environment variables for LM Studio settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ When it is displayed automatically, the menu is sent as its own message before t
 
 ### Customizing
 
- - Update `API_BASE` if your LM Studio server is running on a different host or port.
- - Modify `MODEL_NAME`, `CHUNK_SIZE`, or `CHUNK_DELAY` to fit your setup or preferences.
+ - Set the environment variables `MESHTASTIC_API_BASE`, `MESHTASTIC_API_KEY`, and
+   `MESHTASTIC_MODEL_NAME` to override the LM Studio API base URL, API key, and
+   model name. They default to `http://localhost:1234/v1`, `lm-studio`, and
+   `mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF` respectively.
+ - Modify `CHUNK_BYTES`, `CHANNEL_CHUNK_BYTES`, or the `DELAY_MIN`/`DELAY_MAX`
+   values to fit your setup or preferences.
  - `MAX_HISTORY_LEN` controls how many messages per peer are kept in memory.
  - `MAX_WORKERS` limits how many threads can handle messages concurrently.
 

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -13,9 +13,11 @@ from pubsub import pub
 from meshtastic.serial_interface import SerialInterface
 
 # ─── CONFIG ────────────────────────────────────────────────────────────────────
-API_BASE = "http://localhost:1234/v1"
-API_KEY = "lm-studio"
-MODEL_NAME = "mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF"
+API_BASE = os.getenv("MESHTASTIC_API_BASE", "http://localhost:1234/v1")
+API_KEY = os.getenv("MESHTASTIC_API_KEY", "lm-studio")
+MODEL_NAME = os.getenv(
+    "MESHTASTIC_MODEL_NAME", "mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF"
+)
 
 SYSTEM_PROMPT = (
 "You're Smudge (Rae 'Ray' McKinnon), a grizzled, caffeine-addicted hacker squatting in a filthy Vegas motel room near DEF CON 33. "


### PR DESCRIPTION
## Summary
- Pull LM Studio API base URL, key, and model name from `MESHTASTIC_API_BASE`, `MESHTASTIC_API_KEY`, and `MESHTASTIC_MODEL_NAME` environment variables.
- Document the new configuration variables in the "Customizing" section of the README.

## Testing
- `pytest -q`
- `python -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_688fae3833c88328a4c5ca2719f614a1