### PR TITLE
Number chunked messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 python meshtastic_llm_bot.py
 ```
 
-When started, the program prompts for which channel(s) (0–3 or *all*) it should respond on. It always answers direct messages. The bot sends back the LLM's response in numbered chunks for easy ordering and occasionally broadcasts a random hacker message for users to reply to on the selected channels.
+When started, the program prompts for which channel(s) (0–3 or *all*) it should respond on. It always answers direct messages. The bot sends back the LLM's response in numbered chunks, prefixed like `[1/3]`, for easy ordering and occasionally broadcasts a random hacker message for users to reply to on the selected channels.
 
 ### Commands
 

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -125,17 +125,19 @@ def split_into_chunks(text: str, size: int):
 
 def send_chunked_text(text: str, target: int, iface, channel=False):
     size = CHANNEL_CHUNK_BYTES if channel else CHUNK_BYTES
-    time.sleep(random.uniform(DELAY_MIN, DELAY_MAX))
-    for i, chunk in enumerate(split_into_chunks(text, size)):
-        if i:
-            time.sleep(random.uniform(DELAY_MIN, DELAY_MAX))
+    chunks = list(split_into_chunks(text, size - 10))
+    total = len(chunks)
+    for i, chunk in enumerate(chunks, 1):
+        time.sleep(random.uniform(DELAY_MIN, DELAY_MAX))
+        chunk = f"[{i}/{total}] {chunk}"
         if channel:
             iface.sendText(chunk, channelIndex=target, wantAck=False)
         else:
             for attempt in range(3):
                 iface.sendText(chunk, target, wantAck=True)
                 try:
-                    iface.waitForAckNak(); break
+                    iface.waitForAckNak()
+                    break
                 except Exception:
                     if attempt == 2:
                         print("WARN: no ACK after 3 tries")


### PR DESCRIPTION
## Summary
- Add [1/n]-style numbering to each chunk transmitted by `send_chunked_text`.
- Mention numbered chunk prefix format in README.

## Testing
- `python -m py_compile meshtastic_llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_688fae3acc908328bbc72a0b8587ff84