### PR TITLE
Pin dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Install Python dependencies with:
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file pins exact versions of the core dependencies
+(`meshtastic==2.2.15`, `pypubsub==4.0.3`, and `requests==2.31.0`) to ensure
+they work together.
+
 ## Usage
 
 1. Start LM Studio and load the desired model. The script defaults to `mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF`, but you can change this in `meshtastic_llm_bot.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-meshtastic
-pypubsub
-requests
+meshtastic==2.2.15
+pypubsub==4.0.3
+requests==2.31.0


### PR DESCRIPTION
## Summary
- Pin meshtastic, pypubsub, and requests versions in requirements
- Document pinned versions in installation instructions

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python meshtastic_llm_bot.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_688fae3c5d788328a63c841cc2aa33be