### PR TITLE
Add guard layer for incoming message sanitization

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -83,6 +83,28 @@ GREET_JITTER = 900             # ±15 minutes in seconds
 # ─── END CONFIG ────────────────────────────────────────────────────────────────
 
 
+# ─── GUARD LAYER ───────────────────────────────────────────────────────────────
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+BLOCK_PATTERNS = [
+    re.compile(r"<script", re.IGNORECASE),
+    re.compile(r"\b(drop|delete|insert|update)\b", re.IGNORECASE),
+]
+
+
+def screen_text(text: str) -> str | None:
+    """Sanitize ``text`` and block common malicious patterns.
+
+    Returns sanitized text, or ``None`` if the message should be dropped.
+    """
+    cleaned = CONTROL_CHARS_RE.sub("", text).strip()
+    if not cleaned:
+        return None
+    for pat in BLOCK_PATTERNS:
+        if pat.search(cleaned):
+            return None
+    return cleaned
+# ───────────────────────────────────────────────────────────────────────────────
+
 # ─── STATE ─────────────────────────────────────────────────────────────────────
 histories: dict[int, list[dict]] = {}
 history_lock = threading.Lock()
@@ -229,6 +251,7 @@ def handle_message(target: int, text: str, iface, is_channel=False):
     except Exception as e:
         reply = f"Error: {e}"
 
+    reply = screen_text(reply) or "Content blocked."
     record_message(target, "assistant", reply)
     log_message("OUT", target, reply, channel=is_channel)
     send_chunked_text(reply, target, iface, channel=is_channel)
@@ -256,16 +279,16 @@ def on_receive(packet=None, interface=None, **kwargs):
         except (TypeError, ValueError):
             channel = None
         to = pkt.get("to")
-        text = pkt.get("decoded", {}).get("text", "").strip()
+        raw_text = pkt.get("decoded", {}).get("text", "").strip()
         logger.debug(
             "chan_raw=%s parsed=%s to=%s from=%s text='%s'",
             chan_info,
             channel,
             to,
             pkt.get("from"),
-            text,
+            raw_text,
         )
-        if not text:
+        if not raw_text:
             logger.debug("no text; ignoring packet")
             return
 
@@ -285,16 +308,21 @@ def on_receive(packet=None, interface=None, **kwargs):
             logger.debug("ignoring own message")
             return
 
-        if not is_addressed(text, is_dm, channel, src):
+        if not is_addressed(raw_text, is_dm, channel, src):
             logger.debug("message not addressed to bot; ignoring")
+            return
+
+        screened = screen_text(raw_text)
+        if screened is None:
+            logger.debug("message rejected by guard layer")
             return
 
         if not is_dm:
             mark_addressed(channel, src)
 
         target = src if is_dm else channel
-        log_message("IN", target, text, channel=not is_dm)
-        executor.submit(handle_message, target, text, iface, not is_dm)
+        log_message("IN", target, screened, channel=not is_dm)
+        executor.submit(handle_message, target, screened, iface, not is_dm)
     except Exception as e:
         logger.warning("Error in on_receive: %s", e)
 


### PR DESCRIPTION
## Summary
- Add guard functions to strip control characters and block basic malicious patterns
- Screen incoming packets through guard before logging or forwarding to the model
- Sanitize model responses to prevent unsafe output
- Skip messages that become empty after sanitization

## Testing
- `python -m py_compile meshtastic_llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_688fb60ced7c8328b124b78fb74c428e