### PR TITLE
Harden Smudge bot and add unit tests

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,44 @@
+import os, sys, types
+os.environ.setdefault("MESHTASTIC_API_KEY", "test")
+
+meshtastic_stub = types.ModuleType("meshtastic")
+serial_stub = types.ModuleType("serial_interface")
+class DummySerial:
+    pass
+serial_stub.SerialInterface = DummySerial
+meshtastic_stub.serial_interface = serial_stub
+sys.modules["meshtastic"] = meshtastic_stub
+sys.modules["meshtastic.serial_interface"] = serial_stub
+
+pubsub_stub = types.ModuleType("pubsub")
+pubsub_stub.pub = types.SimpleNamespace(subscribe=lambda *a, **k: None)
+sys.modules["pubsub"] = pubsub_stub
+
+import unittest
+import meshtastic_llm_bot as bot
+
+class StateTests(unittest.TestCase):
+    def setUp(self):
+        bot.histories.clear()
+        bot.last_addressed.clear()
+
+    def test_split_into_chunks(self):
+        text = "a" * 500
+        chunks = list(bot.split_into_chunks(text, 100))
+        self.assertTrue(all(len(c.encode("utf-8")) <= 100 for c in chunks))
+        self.assertEqual("".join(chunks), text)
+
+    def test_record_message_prunes(self):
+        peer = 1
+        for i in range(bot.MAX_HISTORY_LEN + 5):
+            bot.record_message(peer, "user", f"m{i}")
+        self.assertLessEqual(len(bot.histories[peer]), bot.MAX_HISTORY_LEN + 1)
+
+    def test_is_addressed_regex(self):
+        peer = 1
+        channel = 0
+        self.assertFalse(bot.is_addressed("hello", False, channel, peer))
+        self.assertTrue(bot.is_addressed("hey smudge", False, channel, peer))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce HTTPS API endpoint and require API key via env var
- sanitize and bound incoming/outgoing text, dropping oversized packets
- add CLI auth token, TLS-verified HTTP requests, and basic prompt filter
- add unit tests for message splitting, history pruning, and addressing

## Testing
- `python -m py_compile meshtastic_llm_bot.py`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6890a737afd083288aec42bca2b98b31