### PR TITLE
Handle weather command after handle mention

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -230,6 +230,7 @@ def is_addressed(text: str, direct: bool, channel_id: int, user: int) -> bool:
 
 def handle_message(target: int, text: str, iface, is_channel=False):
     text = safe_text(text)
+    text = re.sub(r"^\s*smudge[:,]?\s*", "", text, flags=re.IGNORECASE)
     lower = text.lower()
 
     if not is_safe_prompt(text):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -40,5 +40,31 @@ class StateTests(unittest.TestCase):
         self.assertFalse(bot.is_addressed("hello", False, channel, peer))
         self.assertTrue(bot.is_addressed("hey smudge", False, channel, peer))
 
+    def test_weather_command_with_handle(self):
+        outputs = {}
+
+        def fake_get_weather(loc):
+            outputs["loc"] = loc
+            return f"Weather for {loc}"
+
+        def fake_send_chunked(text, target, iface, channel=False):
+            outputs["reply"] = text
+
+        orig_get_weather = bot.get_weather
+        orig_send_chunked = bot.send_chunked_text
+        orig_log_message = bot.log_message
+        bot.get_weather = fake_get_weather
+        bot.send_chunked_text = fake_send_chunked
+        bot.log_message = lambda *a, **k: None
+        try:
+            bot.handle_message(1, "smudge weather Paris", object(), True)
+        finally:
+            bot.get_weather = orig_get_weather
+            bot.send_chunked_text = orig_send_chunked
+            bot.log_message = orig_log_message
+
+        self.assertEqual(outputs.get("loc"), "Paris")
+        self.assertEqual(outputs.get("reply"), "Weather for Paris")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Strip leading `smudge` handle so commands like `weather` still execute when addressed by name
- Add regression test ensuring weather queries work when prefixed with the bot's handle

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890acef1f208328899f05f37dc1407f