### PR TITLE
Increase console log verbosity

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -18,7 +18,7 @@ from pubsub import pub
 from meshtastic.serial_interface import SerialInterface
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format="%(asctime)s %(levelname)s %(message)s",
     stream=sys.stdout,
 )


### PR DESCRIPTION
## Summary
- show bot activity on the console by logging at DEBUG level

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b5d683048328971b6495d2d0611d