### PR TITLE
Add text adventure module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ When started, the program prompts for which channel(s) (0–3 or *all*) it shoul
 The command menu is shown only on your first message to the bot or whenever you send `help`.
 When it is displayed automatically, the menu is sent as its own message before the bot replies to your request.
 
+## Text Adventure Module
+
+A small Zork-like text adventure engine is available in the `adventure` package. Run it with:
+
+```bash
+python -m adventure.game
+```
+
+The game loads a 30-room world from JSON data, supports standard adventure commands, scoring, and save/restore.
+
 ### Customizing
 
  - Set the environment variables `MESHTASTIC_API_BASE`, `MESHTASTIC_API_KEY`, and

--- a/adventure/__init__.py
+++ b/adventure/__init__.py
@@ -1,0 +1,3 @@
+"""Zork-like text adventure engine."""
+from .game import Game, register_verb
+__all__ = ["Game", "register_verb"]

--- a/adventure/game.py
+++ b/adventure/game.py
@@ -1,0 +1,270 @@
+import json
+import os
+import random
+from typing import Dict, List, Tuple, Callable
+
+# Parser plugin registry
+_VERBS: Dict[str, Callable] = {}
+
+
+def register_verb(verb: str, func: Callable):
+    """Register a new verb with the parser."""
+    _VERBS[verb] = func
+
+
+class Parser:
+    directions = {
+        "n": "north",
+        "s": "south",
+        "e": "east",
+        "w": "west",
+        "u": "up",
+        "d": "down",
+    }
+
+    def parse(self, text: str) -> List[Tuple[str, str, str]]:
+        """Parse input into a list of (verb, noun, prep) commands."""
+        commands = []
+        text = text.lower().strip()
+        for part in text.split(" and "):
+            tokens = part.split()
+            if not tokens:
+                continue
+            if tokens[0] in self.directions:
+                verb = self.directions[tokens[0]]
+            else:
+                verb = tokens[0]
+            noun = tokens[1] if len(tokens) > 1 else ""
+            prep = tokens[2] if len(tokens) > 2 else ""
+            commands.append((verb, noun, prep))
+        return commands
+
+
+class Item:
+    def __init__(self, name: str, weight: int, desc: str, can_carry: bool=True):
+        self.name = name
+        self.weight = weight
+        self.desc = desc
+        self.can_carry = can_carry
+
+    def __repr__(self):
+        return self.name
+
+
+class Room:
+    def __init__(self, data: Dict):
+        self.id = data["id"]
+        self.name = data["name"]
+        self.desc = data["desc"]
+        self.exits = data["exits"]
+        self.item_names = data.get("items", [])
+        self.state = data.get("state", {"lit": True, "locked": False})
+        self.items: List[Item] = []  # populated later
+
+
+class Game:
+    max_weight = 10
+
+    def __init__(self, data_path: str = None):
+        self.parser = Parser()
+        self.verbose = False
+        self.move_count = 0
+        self.score = 0
+        self.total_score = 100
+        self.thief_has_item = None
+        self.thief_room = 30
+        data_path = data_path or os.path.join(os.path.dirname(__file__), "world.json")
+        with open(data_path) as f:
+            data = json.load(f)
+        self.items: Dict[str, Item] = {}
+        for key, val in data["items"].items():
+            self.items[key] = Item(**val)
+        self.rooms: Dict[int, Room] = {}
+        for rdata in data["rooms"]:
+            room = Room(rdata)
+            room.items = [self.items[name] for name in room.item_names]
+            self.rooms[room.id] = room
+        self.player_room = 1
+        self.inventory: List[Item] = []
+        self.locked_doors = {10: {"east": True}}  # door east of room10 locked
+        self.required_items = {"lamp": False, "key": False, "lockpick": False}
+
+    # Utility methods
+    def current_room(self) -> Room:
+        return self.rooms[self.player_room]
+
+    def current_weight(self) -> int:
+        return sum(item.weight for item in self.inventory)
+
+    # Command handlers
+    def do_look(self, *_):
+        room = self.current_room()
+        print(room.name)
+        if self.verbose or room.state.get("first", True):
+            print(room.desc)
+            room.state["first"] = False
+        print("Exits: ", ", ".join(room.exits.keys()))
+        if room.items:
+            print("You see:", ", ".join(i.name for i in room.items))
+
+    def do_examine(self, noun, *_):
+        if noun in self.items:
+            item = self.items[noun]
+            print(item.desc)
+        else:
+            print("You see nothing special about it.")
+
+    def do_take(self, noun, *_):
+        room = self.current_room()
+        item = next((i for i in room.items if i.name == noun), None)
+        if not item:
+            print("There is no such item here.")
+            return
+        if not item.can_carry:
+            print("You cannot carry that.")
+            return
+        if self.current_weight() + item.weight > self.max_weight:
+            print("Your load is too heavy.")
+            return
+        room.items.remove(item)
+        self.inventory.append(item)
+        if item.name == "treasure":
+            self.score += 10
+        print("Taken.")
+
+    def do_drop(self, noun, *_):
+        item = next((i for i in self.inventory if i.name == noun), None)
+        if not item:
+            print("You don't have that.")
+            return
+        self.inventory.remove(item)
+        self.current_room().items.append(item)
+        print("Dropped.")
+
+    def do_inventory(self, *_):
+        if not self.inventory:
+            print("You are empty-handed.")
+            return
+        print("You are carrying:")
+        for i in self.inventory:
+            print(f"- {i.name} ({i.weight})")
+        print(f"Total weight: {self.current_weight()}/{self.max_weight}")
+
+    def do_score(self, *_):
+        print(f"Score: {self.score}/{self.total_score}")
+
+    def do_moves(self, *_):
+        print(f"Moves: {self.move_count}")
+
+    def do_save(self, noun="save.json", *_):
+        state = {
+            "player_room": self.player_room,
+            "inventory": [i.name for i in self.inventory],
+            "rooms": {rid: r.state for rid, r in self.rooms.items()},
+            "score": self.score,
+            "move_count": self.move_count,
+            "thief_has_item": self.thief_has_item,
+        }
+        with open(noun, "w") as f:
+            json.dump(state, f)
+        print("Saved.")
+
+    def do_restore(self, noun="save.json", *_):
+        try:
+            with open(noun) as f:
+                state = json.load(f)
+        except Exception:
+            print("Unable to load; start new game?")
+            return
+        self.player_room = state["player_room"]
+        self.inventory = [self.items[name] for name in state["inventory"]]
+        for rid, st in state["rooms"].items():
+            self.rooms[int(rid)].state = st
+        self.score = state.get("score", 0)
+        self.move_count = state.get("move_count", 0)
+        self.thief_has_item = state.get("thief_has_item")
+        print("Restored.")
+
+    def do_use(self, noun, prep, *_):
+        if noun == "lamp":
+            self.required_items["lamp"] = True
+            print("The lamp is now lit.")
+            return
+        if noun == "key" and prep == "door":
+            self.unlock_door()
+            return
+        if noun == "lockpick" and prep == "door":
+            self.unlock_door()
+            return
+        if noun == "scroll":
+            print("The scroll reveals a secret: score +5!")
+            self.score += 5
+            return
+        print("Nothing happens.")
+
+    def unlock_door(self):
+        if not self.locked_doors.get(10, {}).get("east"):
+            print("The door is already unlocked.")
+            return
+        self.locked_doors[10]["east"] = False
+        print("The door unlocks.")
+        self.score += 5
+
+    def do_move(self, direction):
+        room = self.current_room()
+        if direction not in room.exits:
+            print("You can't go that way.")
+            return
+        if self.locked_doors.get(room.id, {}).get(direction):
+            print("The way is locked.")
+            return
+        new_room = room.exits[direction]
+        self.player_room = new_room
+        # random thief event
+        if self.inventory and random.random() < 0.1 and not self.thief_has_item:
+            stolen = random.choice(self.inventory)
+            self.inventory.remove(stolen)
+            self.rooms[self.thief_room].items.append(stolen)
+            self.thief_has_item = stolen.name
+            print(f"A thief snatches your {stolen.name} and runs away!")
+        room = self.current_room()
+        if room.id == self.thief_room and self.thief_has_item:
+            item = next(i for i in room.items if i.name == self.thief_has_item)
+            room.items.remove(item)
+            self.inventory.append(item)
+            print(f"You reclaim your {item.name} from the thief.")
+            self.thief_has_item = None
+        if not room.state.get("lit") and not self.required_items["lamp"]:
+            print("It is pitch dark.")
+        else:
+            self.do_look()
+
+    def do_verbose(self, *_):
+        """Toggle verbose room descriptions."""
+        self.verbose = not self.verbose
+        print("Verbose" if self.verbose else "Brief")
+
+    def unknown(self, verb, *_):
+        print(f"I don't know the word '{verb}'; try LOOK or EXAMINE")
+
+    def run_command(self, verb, noun, prep):
+        self.move_count += 1
+        if verb in ("north", "south", "east", "west", "up", "down"):
+            self.do_move(verb)
+            return
+        func = getattr(self, f"do_{verb}", None) or _VERBS.get(verb)
+        if func:
+            func(noun, prep)
+        else:
+            self.unknown(verb)
+
+    def loop(self):
+        self.do_look()
+        while True:
+            cmd = input("> ")
+            for verb, noun, prep in self.parser.parse(cmd):
+                self.run_command(verb, noun, prep)
+
+
+if __name__ == "__main__":
+    Game().loop()

--- a/adventure/world.json
+++ b/adventure/world.json
@@ -1,0 +1,504 @@
+{
+  "rooms": [
+    {
+      "id": 1,
+      "name": "Room 1",
+      "desc": "This is room 1.",
+      "exits": {
+        "south": 7,
+        "east": 2
+      },
+      "items": [
+        "lamp"
+      ],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 2,
+      "name": "Room 2",
+      "desc": "This is room 2.",
+      "exits": {
+        "south": 8,
+        "west": 1,
+        "east": 3
+      },
+      "items": [
+        "key"
+      ],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 3,
+      "name": "Room 3",
+      "desc": "This is room 3.",
+      "exits": {
+        "south": 9,
+        "west": 2,
+        "east": 4
+      },
+      "items": [
+        "lockpick"
+      ],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 4,
+      "name": "Room 4",
+      "desc": "This is room 4.",
+      "exits": {
+        "south": 10,
+        "west": 3,
+        "east": 5
+      },
+      "items": [
+        "treasure"
+      ],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 5,
+      "name": "Room 5",
+      "desc": "This is room 5.",
+      "exits": {
+        "south": 11,
+        "west": 4,
+        "east": 6
+      },
+      "items": [
+        "scroll"
+      ],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 6,
+      "name": "Room 6",
+      "desc": "This is room 6.",
+      "exits": {
+        "south": 12,
+        "west": 5
+      },
+      "items": [],
+      "state": {
+        "lit": false,
+        "locked": false
+      }
+    },
+    {
+      "id": 7,
+      "name": "Room 7",
+      "desc": "This is room 7.",
+      "exits": {
+        "north": 1,
+        "south": 13,
+        "east": 8
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 8,
+      "name": "Room 8",
+      "desc": "This is room 8.",
+      "exits": {
+        "north": 2,
+        "south": 14,
+        "west": 7,
+        "east": 9
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 9,
+      "name": "Room 9",
+      "desc": "This is room 9.",
+      "exits": {
+        "north": 3,
+        "south": 15,
+        "west": 8,
+        "east": 10
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 10,
+      "name": "Room 10",
+      "desc": "This is room 10.",
+      "exits": {
+        "north": 4,
+        "south": 16,
+        "west": 9,
+        "east": 11
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 11,
+      "name": "Room 11",
+      "desc": "This is room 11.",
+      "exits": {
+        "north": 5,
+        "south": 17,
+        "west": 10,
+        "east": 12
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 12,
+      "name": "Room 12",
+      "desc": "This is room 12.",
+      "exits": {
+        "north": 6,
+        "south": 18,
+        "west": 11
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 13,
+      "name": "Room 13",
+      "desc": "This is room 13.",
+      "exits": {
+        "north": 7,
+        "south": 19,
+        "east": 14
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 14,
+      "name": "Room 14",
+      "desc": "This is room 14.",
+      "exits": {
+        "north": 8,
+        "south": 20,
+        "west": 13,
+        "east": 15
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 15,
+      "name": "Room 15",
+      "desc": "This is room 15.",
+      "exits": {
+        "north": 9,
+        "south": 21,
+        "west": 14,
+        "east": 16
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 16,
+      "name": "Room 16",
+      "desc": "This is room 16.",
+      "exits": {
+        "north": 10,
+        "south": 22,
+        "west": 15,
+        "east": 17
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 17,
+      "name": "Room 17",
+      "desc": "This is room 17.",
+      "exits": {
+        "north": 11,
+        "south": 23,
+        "west": 16,
+        "east": 18
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 18,
+      "name": "Room 18",
+      "desc": "This is room 18.",
+      "exits": {
+        "north": 12,
+        "south": 24,
+        "west": 17
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 19,
+      "name": "Room 19",
+      "desc": "This is room 19.",
+      "exits": {
+        "north": 13,
+        "south": 25,
+        "east": 20
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 20,
+      "name": "Room 20",
+      "desc": "This is room 20.",
+      "exits": {
+        "north": 14,
+        "south": 26,
+        "west": 19,
+        "east": 21
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 21,
+      "name": "Room 21",
+      "desc": "This is room 21.",
+      "exits": {
+        "north": 15,
+        "south": 27,
+        "west": 20,
+        "east": 22
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 22,
+      "name": "Room 22",
+      "desc": "This is room 22.",
+      "exits": {
+        "north": 16,
+        "south": 28,
+        "west": 21,
+        "east": 23
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 23,
+      "name": "Room 23",
+      "desc": "This is room 23.",
+      "exits": {
+        "north": 17,
+        "south": 29,
+        "west": 22,
+        "east": 24
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 24,
+      "name": "Room 24",
+      "desc": "This is room 24.",
+      "exits": {
+        "north": 18,
+        "south": 30,
+        "west": 23
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 25,
+      "name": "Room 25",
+      "desc": "This is room 25.",
+      "exits": {
+        "north": 19,
+        "east": 26
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 26,
+      "name": "Room 26",
+      "desc": "This is room 26.",
+      "exits": {
+        "north": 20,
+        "west": 25,
+        "east": 27
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 27,
+      "name": "Room 27",
+      "desc": "This is room 27.",
+      "exits": {
+        "north": 21,
+        "west": 26,
+        "east": 28
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 28,
+      "name": "Room 28",
+      "desc": "This is room 28.",
+      "exits": {
+        "north": 22,
+        "west": 27,
+        "east": 29
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 29,
+      "name": "Room 29",
+      "desc": "This is room 29.",
+      "exits": {
+        "north": 23,
+        "west": 28,
+        "east": 30
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    },
+    {
+      "id": 30,
+      "name": "Room 30",
+      "desc": "This is room 30.",
+      "exits": {
+        "north": 24,
+        "west": 29
+      },
+      "items": [],
+      "state": {
+        "lit": true,
+        "locked": false
+      }
+    }
+  ],
+  "items": {
+    "lamp": {
+      "name": "lamp",
+      "weight": 1,
+      "desc": "An old oil lamp",
+      "can_carry": true
+    },
+    "key": {
+      "name": "key",
+      "weight": 1,
+      "desc": "A small brass key",
+      "can_carry": true
+    },
+    "lockpick": {
+      "name": "lockpick",
+      "weight": 1,
+      "desc": "A makeshift lockpick",
+      "can_carry": true
+    },
+    "treasure": {
+      "name": "treasure",
+      "weight": 5,
+      "desc": "Shiny treasure",
+      "can_carry": true
+    },
+    "scroll": {
+      "name": "scroll",
+      "weight": 1,
+      "desc": "A mysterious scroll",
+      "can_carry": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `adventure` package hosting a Zork-like engine
- load 30-room world from JSON with items, puzzles and random events
- document how to run the adventure module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890db4054e083288f1350fd78e75415