### PR TITLE
Enable Zork adventure game in chat

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -18,6 +18,7 @@ from meshtastic.serial_interface import SerialInterface
 
 from weather import get_weather
 from bbs import handle_bbs, bbs_posts
+from zork import handle_zork
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -70,6 +71,8 @@ MENU = (
     "- bbs post <msg>: add a post\n"
     "- bbs list: show posts\n"
     "- bbs read <n>: read post n\n"
+    "- zork start: begin adventure game\n"
+    "- zork <cmd>: play the game\n"
     "- anything else: chat with the language model"
 )
 DEFAULT_LOCATION = "San Francisco"
@@ -203,6 +206,9 @@ def is_addressed(text: str, direct: bool, channel_id: int, user: int) -> bool:
     if lower.startswith("weather"):
         mark_addressed(channel_id, user)
         return True
+    if lower.startswith("zork"):
+        mark_addressed(channel_id, user)
+        return True
     if HANDLE_RE.search(text):
         mark_addressed(channel_id, user)
         return True
@@ -222,6 +228,12 @@ def handle_message(target: int, text: str, iface, is_channel=False, user=None):
         parts = text.split(maxsplit=1)
         cmd = parts[1] if len(parts) > 1 else ""
         handle_bbs(target, cmd, iface, is_channel, user, log_message, send_chunked_text)
+        return
+
+    if lower.startswith("zork"):
+        parts = text.split(maxsplit=1)
+        cmd = parts[1] if len(parts) > 1 else ""
+        handle_zork(target, cmd, iface, is_channel, user, log_message, send_chunked_text)
         return
 
     if not is_safe_prompt(text):

--- a/zork.py
+++ b/zork.py
@@ -1,0 +1,52 @@
+import io
+import threading
+from contextlib import redirect_stdout
+from typing import Dict
+
+from adventure import Game
+
+MAX_TEXT_LEN = 1024
+
+
+def _safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
+    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]
+
+
+games: Dict[int, Game] = {}
+_games_lock = threading.Lock()
+
+
+def handle_zork(target: int, command: str, iface, is_channel: bool, user: int | None,
+                log_message, send_chunked_text) -> None:
+    command = command.strip()
+    key = user if user is not None else target
+    with _games_lock:
+        game = games.get(key)
+        if not command or command == "help":
+            reply = "Usage: zork start|quit|<command>"
+        elif command == "start":
+            game = Game()
+            games[key] = game
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                game.do_look()
+            reply = buf.getvalue().strip()
+        elif command in ("quit", "exit"):
+            if key in games:
+                del games[key]
+                reply = "Game over."
+            else:
+                reply = "No active game."
+        else:
+            if not game:
+                reply = "No active game. Type 'zork start' to begin."
+            else:
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    for verb, noun, prep in game.parser.parse(command):
+                        game.run_command(verb, noun, prep)
+                reply = buf.getvalue().strip() or "..."
+
+    reply = _safe_text(reply)
+    log_message("OUT", target, reply, channel=is_channel)
+    send_chunked_text(reply, target, iface, channel=is_channel)


### PR DESCRIPTION
## Summary
- add Zork text adventure command handler
- extend bot help menu and addressing logic for new game
- support starting and playing the adventure via chat

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890dcf72bcc8328bfe03f821d0d848f