### PR TITLE
Improve Zork instructions and include help at startup

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -79,8 +79,8 @@ DEFAULT_LOCATION = "San Francisco"
 HELLO_MESSAGES = ["Yo.", "Hey all.", "Smudge here."]
 BOOT_MESSAGE = (
     "DM me or say 'smudge' if you expect a reply. "
-    "I remember the thread for about two minutes."
-)
+    "I remember the thread for about two minutes.\n"
+) + MENU
 GREET_INTERVAL = 4 * 3600
 GREET_JITTER = 900
 
@@ -207,7 +207,6 @@ def is_addressed(text: str, direct: bool, channel_id: int, user: int) -> bool:
         mark_addressed(channel_id, user)
         return True
     if lower.startswith("zork"):
-        mark_addressed(channel_id, user)
         return True
     if HANDLE_RE.search(text):
         mark_addressed(channel_id, user)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -59,6 +59,28 @@ class StateTests(unittest.TestCase):
         channel = 0
         self.assertTrue(bot.is_addressed("zork start", False, channel, peer))
 
+    def test_boot_message_includes_menu(self):
+        self.assertIn(bot.MENU, bot.BOOT_MESSAGE)
+
+    def test_zork_usage_mentions_prefix(self):
+        outputs = []
+
+        def fake_send(text, target, iface, channel=False):
+            outputs.append(text)
+
+        orig_send = bot.send_chunked_text
+        orig_log = bot.log_message
+        bot.send_chunked_text = fake_send
+        bot.log_message = lambda *a, **k: None
+        try:
+            bot.handle_message(0, "zork", object(), True, user=42)
+        finally:
+            bot.send_chunked_text = orig_send
+            bot.log_message = orig_log
+
+        self.assertTrue(outputs)
+        self.assertIn("prefix", outputs[0].lower())
+
     def test_weather_command_with_handle(self):
         outputs = {}
 
@@ -146,6 +168,7 @@ class StateTests(unittest.TestCase):
             zork.games.clear()
 
         self.assertIn("Room 1", outputs[0])
+        self.assertIn("zork north", outputs[0].lower())
         self.assertIn("Room 2", outputs[1])
 
 if __name__ == "__main__":

--- a/zork.py
+++ b/zork.py
@@ -23,14 +23,19 @@ def handle_zork(target: int, command: str, iface, is_channel: bool, user: int | 
     with _games_lock:
         game = games.get(key)
         if not command or command == "help":
-            reply = "Usage: zork start|quit|<command>"
+            reply = "Usage: zork start|quit|<command>. Prefix every action with 'zork'."
         elif command == "start":
             game = Game()
             games[key] = game
             buf = io.StringIO()
             with redirect_stdout(buf):
                 game.do_look()
-            reply = buf.getvalue().strip()
+            room = buf.getvalue().strip()
+            reply = (
+                f"{room}\n"
+                "Type commands like 'zork north' or 'zork take lamp'. "
+                "Use 'zork quit' to end."
+            )
         elif command in ("quit", "exit"):
             if key in games:
                 del games[key]
@@ -39,7 +44,7 @@ def handle_zork(target: int, command: str, iface, is_channel: bool, user: int | 
                 reply = "No active game."
         else:
             if not game:
-                reply = "No active game. Type 'zork start' to begin."
+                reply = "No active game. Type 'zork start' to begin and prefix every command with 'zork'."
             else:
                 buf = io.StringIO()
                 with redirect_stdout(buf):


### PR DESCRIPTION
## Summary
- show full command menu as part of Smudge's boot message
- clarify Zork usage and require explicit `zork` prefix for every move
- add tests covering new help menu and Zork guidance

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890df2d780c832881becb0bcab45693