### PR TITLE
Fix Zork newline formatting

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -170,6 +170,8 @@ class StateTests(unittest.TestCase):
         self.assertIn("Room 1", outputs[0])
         self.assertIn("zork north", outputs[0].lower())
         self.assertIn("Room 2", outputs[1])
+        self.assertIn("\n", outputs[0])
+        self.assertNotIn("\\n", outputs[0])
 
 if __name__ == "__main__":
     unittest.main()

--- a/zork.py
+++ b/zork.py
@@ -52,6 +52,6 @@ def handle_zork(target: int, command: str, iface, is_channel: bool, user: int | 
                         game.run_command(verb, noun, prep)
                 reply = buf.getvalue().strip() or "..."
 
-    reply = _safe_text(reply)
-    log_message("OUT", target, reply, channel=is_channel)
+    safe_reply = _safe_text(reply)
+    log_message("OUT", target, safe_reply, channel=is_channel)
     send_chunked_text(reply, target, iface, channel=is_channel)


### PR DESCRIPTION
## Summary
- preserve newline characters in Zork game responses
- test that Zork output sends real newlines instead of escaped `\n`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e147a8408328901570f7947d4092