### PR TITLE
Add DEFCON 33 easter eggs

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -99,7 +99,7 @@ class Game:
     # Command handlers
     def do_look(self, *_):
         room = self.current_room()
-        print(room.name)
+        print(f"Room {room.id}: {room.name}")
         if self.verbose or room.state.get("first", True):
             print(room.desc)
             room.state["first"] = False
@@ -199,6 +199,10 @@ class Game:
         if noun == "scroll":
             print("The scroll reveals a secret: score +5!")
             self.score += 5
+            return
+        if noun == "defcon_badge":
+            print("You flash your DEFCON 33 badge. Somewhere, a modem dials up. Score +33!")
+            self.score += 33
             return
         print("Nothing happens.")
 

--- a/adventure/world.json
+++ b/adventure/world.json
@@ -19,7 +19,7 @@
     {
       "id": 2,
       "name": "Abandoned Guardroom",
-      "desc": "Rusted spears litter the floor and torn banners hang limply from iron rings.",
+      "desc": "Rusted spears litter the floor and torn banners hang limply from iron rings. A faded flyer on the wall advertises DEFCON 33.",
       "exits": {
         "south": 8,
         "west": 1,
@@ -77,7 +77,8 @@
         "east": 6
       },
       "items": [
-        "scroll"
+        "scroll",
+        "defcon_badge"
       ],
       "state": {
         "lit": true,
@@ -524,6 +525,12 @@
       "name": "rope",
       "weight": 3,
       "desc": "A sturdy length of rope - looks reliable.",
+      "can_carry": true
+    },
+    "defcon_badge": {
+      "name": "defcon_badge",
+      "weight": 1,
+      "desc": "A shiny lanyard from DEFCON 33 that hums with hacker energy.",
       "can_carry": true
     },
     "ancient_crown": {


### PR DESCRIPTION
## Summary
- add DEFCON 33 references including a collectible badge and guardroom flyer
- show room numbers in look descriptions and handle the badge as a usable item

## Testing
- `python -m json.tool adventure/world.json`
- `pytest -q`
- `python - <<'PY'
from adventure import Game
from io import StringIO
import sys

def capture(func, *args):
    buf=StringIO()
    old_stdout=sys.stdout
    sys.stdout=buf
    try:
        func(*args)
    finally:
        sys.stdout=old_stdout
    return buf.getvalue()

g=Game()
print(capture(g.do_look))
for move in ["east","east","east","east"]:
    print('>', move)
    print(capture(g.do_move, move))
print('Take defcon_badge')
print(capture(g.do_take, 'defcon_badge'))
print('Use defcon_badge')
print(capture(g.do_use, 'defcon_badge', ''))
print('Score:')
print(capture(g.do_score))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890e64b634083289d350a38039f1c11