### PR TITLE
Refactor text sanitization into shared utility

### DIFF
--- a/bbs.py
+++ b/bbs.py
@@ -4,19 +4,13 @@ import tempfile
 import threading
 from typing import Dict, List
 
-
-MAX_TEXT_LEN = 1024
+from utils.text import MAX_TEXT_LEN, safe_text
 BBS_DIR = os.path.abspath(os.getenv("MESHTASTIC_BBS_DIR", "bbs_data"))
 os.makedirs(BBS_DIR, exist_ok=True, mode=0o700)
 try:
     os.chmod(BBS_DIR, 0o700)
 except OSError:
     pass
-
-
-def _safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
-    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]
-
 
 def _board_path(target: int) -> str:
     return os.path.join(BBS_DIR, f"{target}.json")
@@ -90,7 +84,7 @@ def handle_bbs(
                 reply = "Usage: bbs read <n>"
         else:
             content = command[5:].strip() if command.startswith("post ") else command
-            content = _safe_text(content)
+            content = safe_text(content, MAX_TEXT_LEN)
             entry = f"{user}: {content}" if user is not None else content
             board.append(entry)
             _save_board(target, board)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+# Utility modules for meshtastic LLM project
+

--- a/utils/text.py
+++ b/utils/text.py
@@ -1,0 +1,6 @@
+MAX_TEXT_LEN = 1024
+MAX_LOC_LEN = 256
+
+def safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
+    """Escape newlines and carriage returns and truncate to max_len."""
+    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]

--- a/weather.py
+++ b/weather.py
@@ -1,16 +1,12 @@
 import requests
 from urllib.parse import quote_plus
 
-MAX_LOC_LEN = 256
-
-
-def _safe_text(s: str, max_len: int = MAX_LOC_LEN) -> str:
-    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]
+from utils.text import MAX_LOC_LEN, safe_text
 
 
 def get_weather(loc: str = "") -> str:
     try:
-        loc = _safe_text(loc)
+        loc = safe_text(loc, MAX_LOC_LEN)
         url = f"https://wttr.in/{quote_plus(loc) if loc else ''}?format=3&u"
         r = requests.get(url, timeout=5, verify=True, allow_redirects=False)
         if r.status_code == 200:

--- a/zork.py
+++ b/zork.py
@@ -4,13 +4,7 @@ from contextlib import redirect_stdout
 from typing import Dict
 
 from adventure import Game
-
-MAX_TEXT_LEN = 1024
-
-
-def _safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
-    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]
-
+from utils.text import MAX_TEXT_LEN, safe_text
 
 games: Dict[int, Game] = {}
 _games_lock = threading.Lock()
@@ -52,6 +46,6 @@ def handle_zork(target: int, command: str, iface, is_channel: bool, user: int | 
                         game.run_command(verb, noun, prep)
                 reply = buf.getvalue().strip() or "..."
 
-    safe_reply = _safe_text(reply)
+    safe_reply = safe_text(reply, MAX_TEXT_LEN)
     log_message("OUT", target, safe_reply, channel=is_channel)
     send_chunked_text(reply, target, iface, channel=is_channel)


### PR DESCRIPTION
## Summary
- add `utils.text` module with `MAX_TEXT_LEN`, `MAX_LOC_LEN`, and `safe_text`
- replace per-file `safe_text` implementations with shared import
- centralize text length constants across bbs, weather, zork, and bot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892216861548328bbba48a083fdbcae