### PR TITLE
refactor: remove verb registration

### DIFF
--- a/adventure/__init__.py
+++ b/adventure/__init__.py
@@ -1,2 +1,3 @@
-from .game import Game, register_verb
-__all__ = ["Game", "register_verb"]
+from .game import Game
+
+__all__ = ["Game"]

--- a/adventure/game.py
+++ b/adventure/game.py
@@ -1,13 +1,7 @@
 import json
 import os
 import random
-from typing import Dict, List, Tuple, Callable
-
-_VERBS: Dict[str, Callable] = {}
-
-
-def register_verb(verb: str, func: Callable):
-    _VERBS[verb] = func
+from typing import Dict, List, Tuple
 
 
 class Parser:
@@ -256,7 +250,7 @@ class Game:
         if verb in ("north", "south", "east", "west", "up", "down"):
             self.do_move(verb)
             return
-        func = getattr(self, f"do_{verb}", None) or _VERBS.get(verb)
+        func = getattr(self, f"do_{verb}", None)
         if func:
             func(noun, prep)
         else:


### PR DESCRIPTION
## Summary
- drop obsolete `_VERBS` registry and `register_verb` helper from adventure game
- simplify command dispatch to call built-in `do_*` methods only
- stop exporting `register_verb` from adventure package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922317900083288862822d7ecbadc5