### PR TITLE
refactor: map item use actions

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -79,6 +79,14 @@ class Game:
         self.inventory: List[Item] = []
         self.locked_doors = {10: {"east": True}}
         self.required_items = {"lamp": False, "key": False, "lockpick": False}
+        self.use_actions = {
+            ("lamp", ""): self._use_lamp,
+            ("key", "door"): self.unlock_door,
+            ("lockpick", "door"): self.unlock_door,
+            ("scroll", ""): self._use_scroll,
+            ("defcon_badge", ""): self._use_defcon_badge,
+            ("queercon_flyer", ""): self._use_queercon_flyer,
+        }
 
     def current_room(self) -> Room:
         return self.rooms[self.player_room]
@@ -175,29 +183,31 @@ class Game:
         print("Restored.")
 
     def do_use(self, noun, prep, *_):
-        if noun == "lamp":
-            self.required_items["lamp"] = True
-            print("The lamp is now lit.")
-            return
-        if noun == "key" and prep == "door":
-            self.unlock_door()
-            return
-        if noun == "lockpick" and prep == "door":
-            self.unlock_door()
-            return
-        if noun == "scroll":
-            print("The scroll reveals a secret: score +5!")
-            self.score += 5
-            return
-        if noun == "defcon_badge":
-            print("You flash your DEFCON 33 badge. A holographic unicorn invites you to QueerCon's mixers at Chillout 2 (16:00-18:00 Thu-Sat). Score +33!")
-            self.score += 33
-            return
-        if noun == "queercon_flyer":
-            print("The flyer details QueerCon, a con-within-a-con for LGBTQ+ hackers and allies. Mixers run Thu-Sat 16:00-18:00 at Chillout 2. Score +5!")
-            self.score += 5
-            return
-        print("Nothing happens.")
+        action = self.use_actions.get((noun, prep))
+        if action:
+            action()
+        else:
+            print("Nothing happens.")
+
+    def _use_lamp(self):
+        self.required_items["lamp"] = True
+        print("The lamp is now lit.")
+
+    def _use_scroll(self):
+        print("The scroll reveals a secret: score +5!")
+        self.score += 5
+
+    def _use_defcon_badge(self):
+        print(
+            "You flash your DEFCON 33 badge. A holographic unicorn invites you to QueerCon's mixers at Chillout 2 (16:00-18:00 Thu-Sat). Score +33!"
+        )
+        self.score += 33
+
+    def _use_queercon_flyer(self):
+        print(
+            "The flyer details QueerCon, a con-within-a-con for LGBTQ+ hackers and allies. Mixers run Thu-Sat 16:00-18:00 at Chillout 2. Score +5!"
+        )
+        self.score += 5
 
     def unlock_door(self):
         if not self.locked_doors.get(10, {}).get("east"):

--- a/tests/test_use_actions.py
+++ b/tests/test_use_actions.py
@@ -1,0 +1,58 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from adventure.game import Game
+
+
+class UseActionTests(unittest.TestCase):
+    def capture(self, func, *args):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            func(*args)
+        return buf.getvalue()
+
+    def test_use_lamp(self):
+        g = Game()
+        out = self.capture(g.do_use, "lamp", "")
+        self.assertIn("lamp is now lit", out)
+        self.assertTrue(g.required_items["lamp"])
+
+    def test_use_key_unlocks_door(self):
+        g = Game()
+        out = self.capture(g.do_use, "key", "door")
+        self.assertFalse(g.locked_doors[10]["east"])
+        self.assertIn("door unlocks", out)
+
+    def test_use_lockpick_unlocks_door(self):
+        g = Game()
+        out = self.capture(g.do_use, "lockpick", "door")
+        self.assertFalse(g.locked_doors[10]["east"])
+        self.assertIn("door unlocks", out)
+
+    def test_use_scroll_increases_score(self):
+        g = Game()
+        out = self.capture(g.do_use, "scroll", "")
+        self.assertEqual(g.score, 5)
+        self.assertIn("score +5", out.lower())
+
+    def test_use_defcon_badge(self):
+        g = Game()
+        out = self.capture(g.do_use, "defcon_badge", "")
+        self.assertEqual(g.score, 33)
+        self.assertIn("score +33", out.lower())
+
+    def test_use_queercon_flyer(self):
+        g = Game()
+        out = self.capture(g.do_use, "queercon_flyer", "")
+        self.assertEqual(g.score, 5)
+        self.assertIn("score +5", out.lower())
+
+    def test_use_unknown_item(self):
+        g = Game()
+        out = self.capture(g.do_use, "unknown", "")
+        self.assertIn("nothing happens", out.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle item usage via a dictionary of action handlers
- cover item use actions with new tests

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68924b85cbc483288a8fe1c47098a041