### PR TITLE
Improve weather error handling and add tests

### DIFF
--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import unittest
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import weather
+
+
+class WeatherErrorTests(unittest.TestCase):
+    def test_http_error_includes_status(self):
+        class DummyResp:
+            status_code = 500
+            reason = "Internal Server Error"
+            text = ""
+
+            def raise_for_status(self):
+                raise requests.HTTPError(response=self)
+
+        def fake_get(*args, **kwargs):
+            return DummyResp()
+
+        orig_get = weather.requests.get
+        weather.requests.get = fake_get
+        try:
+            msg = weather.get_weather("Paris")
+        finally:
+            weather.requests.get = orig_get
+
+        self.assertIn("HTTP 500", msg)
+        self.assertIn("Internal Server Error", msg)
+
+    def test_network_error_includes_reason(self):
+        def fake_get(*args, **kwargs):
+            raise requests.ConnectionError("Network down")
+
+        orig_get = weather.requests.get
+        weather.requests.get = fake_get
+        try:
+            msg = weather.get_weather("Paris")
+        finally:
+            weather.requests.get = orig_get
+
+        self.assertIn("Network down", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weather.py
+++ b/weather.py
@@ -9,8 +9,19 @@ def get_weather(loc: str = "") -> str:
         loc = safe_text(loc, MAX_LOC_LEN)
         url = f"https://wttr.in/{quote_plus(loc) if loc else ''}?format=3&u"
         r = requests.get(url, timeout=5, verify=True, allow_redirects=False)
+        r.raise_for_status()
         if r.status_code == 200:
             return r.text.strip()
+    except requests.RequestException as e:
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        reason = getattr(getattr(e, "response", None), "reason", None)
+        if status is not None:
+            msg = f"HTTP {status}"
+            if reason:
+                msg += f" {reason}"
+        else:
+            msg = str(e)
+        return f"Error retrieving weather: {msg}"
     except Exception as e:
         return f"Error retrieving weather: {e}"
     return "Unable to retrieve weather."


### PR DESCRIPTION
## Summary
- raise HTTP errors in `get_weather` and report status/reason
- add tests covering HTTP and network failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689253f7cd208328953cb067c34bba9f