### PR TITLE
Remove specific channel references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ they work together.
 python meshtastic_llm_bot.py
 ```
 
-When started, the program prompts for which channel(s) (0–4 or *all*) it should respond on. Channel 4 is preconfigured as **Queer_Chat**, mirroring the Emerald channel's setup. It always answers direct messages. The bot sends back the LLM's response in numbered chunks, prefixed like `[1/3]`, for easy ordering and occasionally broadcasts a random hacker message for users to reply to on the selected channels.
+When started, the program prompts for which channel(s) (0–4 or *all*) it should respond on. It always answers direct messages. The bot sends back the LLM's response in numbered chunks, prefixed like `[1/3]`, for easy ordering and occasionally broadcasts a random hacker message for users to reply to on the selected channels.
 
 ### Commands
 


### PR DESCRIPTION
## Summary
- Remove references to Queer_Chat and Emerald channel from README.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937356bd348328912579bb8e995ff6