### PR TITLE
Escape control characters in text before sending to Meshtastic

### DIFF
--- a/tests/test_safe_text.py
+++ b/tests/test_safe_text.py
@@ -1,0 +1,26 @@
+import os, sys, types, tempfile, shutil, atexit
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("MESHTASTIC_API_KEY", "test")
+os.environ.setdefault("MESHTASTIC_SOUL", "cipher")
+
+BBS_DIR = tempfile.mkdtemp(prefix="bbs-test-")
+os.environ["MESHTASTIC_BBS_DIR"] = BBS_DIR
+atexit.register(lambda: shutil.rmtree(BBS_DIR, ignore_errors=True))
+
+
+import unittest
+
+from utils.text import safe_text
+
+
+class SafeTextTests(unittest.TestCase):
+    def test_escapes_control_chars(self):
+        raw = "hello\nworld\r\x00\x1b!"
+        expected = "hello\\nworld\\r\\x00\\x1b!"
+        self.assertEqual(safe_text(raw), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/utils/text.py
+++ b/utils/text.py
@@ -1,6 +1,20 @@
+import re
+
 MAX_TEXT_LEN = 1024
 MAX_LOC_LEN = 256
 
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _escape_control(match: re.Match) -> str:
+    c = match.group(0)
+    if c == "\n":
+        return "\\n"
+    if c == "\r":
+        return "\\r"
+    return f"\\x{ord(c):02x}"
+
+
 def safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
-    """Escape newlines and carriage returns and truncate to max_len."""
-    return s.replace("\r", "\\r").replace("\n", "\\n")[:max_len]
+    """Escape control characters and truncate to max_len."""
+    return _CONTROL_CHARS_RE.sub(_escape_control, s)[:max_len]


### PR DESCRIPTION
## Summary
- escape all control characters in outgoing/incoming text
- add unit test for control character escaping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a0d8ea2248328a043fa59e197bc0c