### PR TITLE
Strip placeholder tokens from LLM responses

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -409,7 +409,6 @@ def handle_message(
         )
         r.raise_for_status()
         reply = r.json()["choices"][0]["message"]["content"].strip()
-        reply = re.sub(r'\s*\[USER_DATA\]\s*', ' ', reply).strip()
     except requests.HTTPError as e:
         status = e.response.status_code if e.response else "unknown"
         detail = e.response.text.strip() if e.response else str(e)

--- a/tests/test_safe_text.py
+++ b/tests/test_safe_text.py
@@ -20,6 +20,10 @@ class SafeTextTests(unittest.TestCase):
         expected = "hello\\nworld\\r\\x00\\x1b!"
         self.assertEqual(safe_text(raw), expected)
 
+    def test_strips_placeholders(self):
+        raw = "Hey, [USERNAME]! [USER_DATA]"
+        self.assertEqual(safe_text(raw), "Hey, !")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/text.py
+++ b/utils/text.py
@@ -4,6 +4,7 @@ MAX_TEXT_LEN = 1024
 MAX_LOC_LEN = 256
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+_PLACEHOLDER_RE = re.compile(r"\s*\[[A-Z_]+\]\s*")
 
 
 def _escape_control(match: re.Match) -> str:
@@ -16,5 +17,6 @@ def _escape_control(match: re.Match) -> str:
 
 
 def safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
-    """Escape control characters and truncate to max_len."""
+    """Remove placeholders, escape control characters, and truncate."""
+    s = _PLACEHOLDER_RE.sub(" ", s).strip()
     return _CONTROL_CHARS_RE.sub(_escape_control, s)[:max_len]


### PR DESCRIPTION
## Summary
- remove placeholder tokens like `[USERNAME]` from bot output
- centralize placeholder stripping in `safe_text`
- add regression test covering placeholder removal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5a50240c8328b5ae5243b67dea23