### PR TITLE
Align Zork adventure with HOPE

### DIFF
--- a/adventure/game.py
+++ b/adventure/game.py
@@ -84,8 +84,8 @@ class Game:
             ("key", "door"): self.unlock_door,
             ("lockpick", "door"): self.unlock_door,
             ("scroll", ""): self._use_scroll,
-            ("defcon_badge", ""): self._use_defcon_badge,
-            ("queercon_flyer", ""): self._use_queercon_flyer,
+            ("hope_badge", ""): self._use_hope_badge,
+            ("hope_schedule", ""): self._use_hope_schedule,
         }
 
     def current_room(self) -> Room:
@@ -197,15 +197,15 @@ class Game:
         print("The scroll reveals a secret: score +5!")
         self.score += 5
 
-    def _use_defcon_badge(self):
+    def _use_hope_badge(self):
         print(
-            "You flash your DEFCON 33 badge. A holographic unicorn invites you to QueerCon's mixers at Chillout 2 (16:00-18:00 Thu-Sat). Score +33!"
+            "You flash your HOPE 16 badge. A volunteer hands you a zine on lock-picking. Score +16!"
         )
-        self.score += 33
+        self.score += 16
 
-    def _use_queercon_flyer(self):
+    def _use_hope_schedule(self):
         print(
-            "The flyer details QueerCon, a con-within-a-con for LGBTQ+ hackers and allies. Mixers run Thu-Sat 16:00-18:00 at Chillout 2. Score +5!"
+            "The schedule lists talks, workshops, and villages running day and night. Score +5!"
         )
         self.score += 5
 
@@ -249,8 +249,8 @@ class Game:
         self.verbose = not self.verbose
         print("Verbose" if self.verbose else "Brief")
 
-    def do_queercon(self, *_):
-        print("QueerCon is DEFCON's con-within-a-con for LGBTQ+ hackers and allies. Mixers run Thu-Sat 16:00-18:00 at Chillout 2. Everyone is welcome!")
+    def do_hope(self, *_):
+        print("HOPE (Hackers On Planet Earth) is an annual hacker con blending tech, activism, and art. Workshops, villages, and performances run day and night. Everyone is welcome!")
 
     def unknown(self, verb, *_):
         print(f"I don't know the word '{verb}'; try LOOK or EXAMINE")

--- a/adventure/world.json
+++ b/adventure/world.json
@@ -19,7 +19,7 @@
     {
       "id": 2,
       "name": "Abandoned Guardroom",
-      "desc": "Rusted spears litter the floor and torn banners hang limply from iron rings. A faded flyer on the wall advertises DEFCON 33. A rainbow sticker invites you to QueerCon mixers 16:00-18:00 at Chillout 2.",
+      "desc": "Rusted spears litter the floor and torn banners hang limply from iron rings. A poster lists HOPE 16's talks on privacy, activism, and DIY tech. A hand-drawn map points toward late-night villages and workshops.",
       "exits": {
         "south": 8,
         "west": 1,
@@ -27,7 +27,7 @@
       },
       "items": [
         "key",
-        "queercon_flyer"
+        "hope_schedule"
       ],
       "state": {
         "lit": true,
@@ -71,7 +71,7 @@
     {
       "id": 5,
       "name": "Scribe's Library",
-      "desc": "Towering shelves sag under the weight of moldy tomes; parchment scraps drift like leaves.",
+      "desc": "Towering shelves sag under the weight of moldy tomes; parchment scraps drift like leaves. An old HOPE badge glints from under a stack of zines.",
       "exits": {
         "south": 11,
         "west": 4,
@@ -79,7 +79,7 @@
       },
       "items": [
         "scroll",
-        "defcon_badge"
+        "hope_badge"
       ],
       "state": {
         "lit": true,
@@ -528,16 +528,16 @@
       "desc": "A sturdy length of rope - looks reliable.",
       "can_carry": true
     },
-    "defcon_badge": {
-      "name": "defcon_badge",
+    "hope_badge": {
+      "name": "hope_badge",
       "weight": 1,
-      "desc": "A shiny lanyard from DEFCON 33 that hums with hacker energy.",
+      "desc": "A worn lanyard from HOPE 16 buzzing with DIY energy.",
       "can_carry": true
     },
-    "queercon_flyer": {
-      "name": "queercon_flyer",
+    "hope_schedule": {
+      "name": "hope_schedule",
       "weight": 1,
-      "desc": "A vibrant QueerCon flyer inviting all to mixers and panels. Mixers run Thu-Sat 16:00-18:00 at Chillout 2. Everyone is welcome.",
+      "desc": "A pocket schedule listing HOPE talks, workshops, and late-night villages.",
       "can_carry": true
     },
     "ancient_crown": {

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -234,14 +234,14 @@ class StateTests(unittest.TestCase):
         self.assertIn("\\n", outputs[0])
         self.assertEqual(len(outputs[0]), bot.MAX_TEXT_LEN)
 
-    def test_queercon_easter_egg(self):
+    def test_hope_easter_egg(self):
         game = zork.Game()
         buf = io.StringIO()
         with redirect_stdout(buf):
-            game.do_queercon()
+            game.do_hope()
         out = buf.getvalue().lower()
-        self.assertIn("queercon", out)
-        self.assertIn("16:00-18:00", out)
+        self.assertIn("hackers on planet earth", out)
+        self.assertIn("workshops", out)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_use_actions.py
+++ b/tests/test_use_actions.py
@@ -36,15 +36,15 @@ class UseActionTests(unittest.TestCase):
         self.assertEqual(g.score, 5)
         self.assertIn("score +5", out.lower())
 
-    def test_use_defcon_badge(self):
+    def test_use_hope_badge(self):
         g = Game()
-        out = self.capture(g.do_use, "defcon_badge", "")
-        self.assertEqual(g.score, 33)
-        self.assertIn("score +33", out.lower())
+        out = self.capture(g.do_use, "hope_badge", "")
+        self.assertEqual(g.score, 16)
+        self.assertIn("score +16", out.lower())
 
-    def test_use_queercon_flyer(self):
+    def test_use_hope_schedule(self):
         g = Game()
-        out = self.capture(g.do_use, "queercon_flyer", "")
+        out = self.capture(g.do_use, "hope_schedule", "")
         self.assertEqual(g.score, 5)
         self.assertIn("score +5", out.lower())
 


### PR DESCRIPTION
## Summary
- Replace DEFCON-themed references with HOPE 16 in Zork adventure world
- Add HOPE badge and schedule items with corresponding use actions and easter egg command
- Update tests for new HOPE interactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5e6c57388328b5658319fe54ad89