### PR TITLE
Fix Zork output with real line breaks

### DIFF
--- a/tests/test_safe_text.py
+++ b/tests/test_safe_text.py
@@ -17,7 +17,7 @@ from utils.text import safe_text
 class SafeTextTests(unittest.TestCase):
     def test_escapes_control_chars(self):
         raw = "hello\nworld\r\x00\x1b!"
-        expected = "hello\\nworld\\r\\x00\\x1b!"
+        expected = "hello\nworld\r\\x00\\x1b!"
         self.assertEqual(safe_text(raw), expected)
 
     def test_strips_placeholders(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -229,9 +229,9 @@ class StateTests(unittest.TestCase):
             zork.games.clear()
 
         self.assertTrue(outputs)
-        self.assertNotIn("\n", outputs[0])
+        self.assertIn("\n", outputs[0])
+        self.assertNotIn("\\n", outputs[0])
         self.assertNotIn("\r", outputs[0])
-        self.assertIn("\\n", outputs[0])
         self.assertEqual(len(outputs[0]), bot.MAX_TEXT_LEN)
 
     def test_hope_easter_egg(self):

--- a/utils/text.py
+++ b/utils/text.py
@@ -3,16 +3,13 @@ import re
 MAX_TEXT_LEN = 1024
 MAX_LOC_LEN = 256
 
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+# Allow newline and carriage return, escape other control characters
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x09\x0b-\x0c\x0e-\x1f\x7f]")
 _PLACEHOLDER_RE = re.compile(r"\s*\[[A-Z_]+\]\s*")
 
 
 def _escape_control(match: re.Match) -> str:
     c = match.group(0)
-    if c == "\n":
-        return "\\n"
-    if c == "\r":
-        return "\\r"
     return f"\\x{ord(c):02x}"
 
 


### PR DESCRIPTION
## Summary
- Preserve newline characters when sanitizing text so Zork rooms display with proper line breaks
- Update tests for new sanitization behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a642b68dc83288cb79af5d5f87b49