### PR TITLE
strip llm artifacts from replies

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -23,7 +23,7 @@ from meshtastic.serial_interface import SerialInterface
 from weather import get_weather
 from bbs import handle_bbs, bbs_posts
 from zork import handle_zork
-from utils.text import MAX_TEXT_LEN, MAX_LOC_LEN, safe_text
+from utils.text import MAX_TEXT_LEN, MAX_LOC_LEN, safe_text, strip_llm_artifacts
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -418,6 +418,7 @@ def handle_message(
     finally:
         del payload
 
+    reply = strip_llm_artifacts(reply)
     reply = safe_text(reply, MAX_TEXT_LEN)
     record_message(target, "assistant", reply)
     log_message("OUT", target, reply, channel=is_channel)

--- a/tests/test_safe_text.py
+++ b/tests/test_safe_text.py
@@ -11,7 +11,7 @@ atexit.register(lambda: shutil.rmtree(BBS_DIR, ignore_errors=True))
 
 import unittest
 
-from utils.text import safe_text
+from utils.text import safe_text, strip_llm_artifacts
 
 
 class SafeTextTests(unittest.TestCase):
@@ -23,6 +23,15 @@ class SafeTextTests(unittest.TestCase):
     def test_strips_placeholders(self):
         raw = "Hey, [USERNAME]! [USER_DATA]"
         self.assertEqual(safe_text(raw), "Hey, !")
+
+
+class StripLLMArtifactsTests(unittest.TestCase):
+    def test_removes_response_artifact(self):
+        raw = "Answer\n### Response:\nextra"
+        self.assertEqual(strip_llm_artifacts(raw), "Answer")
+
+    def test_handles_no_artifact(self):
+        self.assertEqual(strip_llm_artifacts("Just text"), "Just text")
 
 
 if __name__ == "__main__":

--- a/utils/text.py
+++ b/utils/text.py
@@ -6,6 +6,7 @@ MAX_LOC_LEN = 256
 # Allow newline and carriage return, escape other control characters
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x09\x0b-\x0c\x0e-\x1f\x7f]")
 _PLACEHOLDER_RE = re.compile(r"\s*\[[A-Z_]+\]\s*")
+_LLM_ARTIFACT_RE = re.compile(r"\n?###\s*Response:\s*", re.IGNORECASE)
 
 
 def _escape_control(match: re.Match) -> str:
@@ -17,3 +18,8 @@ def safe_text(s: str, max_len: int = MAX_TEXT_LEN) -> str:
     """Remove placeholders, escape control characters, and truncate."""
     s = _PLACEHOLDER_RE.sub(" ", s).strip()
     return _CONTROL_CHARS_RE.sub(_escape_control, s)[:max_len]
+
+
+def strip_llm_artifacts(s: str) -> str:
+    """Remove dataset artifacts like '### Response:' from model output."""
+    return _LLM_ARTIFACT_RE.split(s, maxsplit=1)[0].strip()


### PR DESCRIPTION
## Summary
- add utility to remove `### Response` artifacts from model output
- strip artifacts before sending replies to users
- test artifact stripping behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0a519acc8328b56c923881b6b4d9