### PR TITLE
Log debug output and broadcast event reminder

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -25,11 +25,24 @@ from bbs import handle_bbs, bbs_posts
 from zork import handle_zork
 from utils.text import MAX_TEXT_LEN, MAX_LOC_LEN, safe_text, strip_llm_artifacts
 
+LOG_DIR = "logs"
+os.makedirs(LOG_DIR, exist_ok=True, mode=0o700)
+
+_date_str = datetime.date.today().isoformat()
+_debug_logfile = os.path.join(LOG_DIR, f"{_date_str}-debug.log")
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s %(levelname)s %(message)s",
-    stream=sys.stdout,
+    handlers=[
+        logging.FileHandler(_debug_logfile, encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ],
 )
+try:
+    os.chmod(_debug_logfile, 0o600)
+except OSError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 SOULS_DIR = Path("souls")
@@ -81,8 +94,6 @@ MAX_HISTORY_LEN = 20
 MAX_CONTEXT_CHARS = 4000
 MAX_WORKERS = 4
 MAX_QUEUE_SIZE = 20
-LOG_DIR = "logs"
-os.makedirs(LOG_DIR, exist_ok=True, mode=0o700)
 
 MAX_PACKET_CHARS = 1024
 
@@ -115,6 +126,33 @@ HANDLE_RE = re.compile(rf"\b{re.escape(HANDLE)}\b", re.IGNORECASE)
 
 GREET_INTERVAL = 4 * 3600
 GREET_JITTER = 900
+
+REMINDER_INTERVAL = 6 * 3600
+REMINDER_JITTER = 900
+EVENT_REMINDER = (
+    "Reminder for tonight - EmeraldCon 2025\n"
+    "The Unofficial HOPE Afterparty\n\n"
+    "Celebrating our third year!\n\n"
+    "Event Dates\n\n"
+    "August 15–17, 2025\n"
+    "Coincides with HOPE_16 at St. John's University, Queens, NY\n\n"
+    "Venue\n\n"
+    "The Emerald Pub\n"
+    "A classic dive bar next to the conference hotel. It's the unofficial HOPE hangout with an authentic Irish pub feel.\n\n"
+    "Address: 183-01 Horace Harding Expy, Star Cafe, Queens, NY 11365\n"
+    "Hours: Opens at 8PM going until 3am\n"
+    "Who Should Attend\n\n"
+    "Hackers & Tinkerers: Whether you're into hardware hacking, software exploits, or just love the culture, you'll find like-minded individuals here.\n"
+    "Security Professionals: From pentesters to red teamers, it's a great place to unwind and share war stories.\n"
+    "Tech Enthusiasts: If you're passionate about technology and its societal impacts, this is your crowd.\n"
+    "Creatives & Artists: The intersection of technology and art is a frequent topic of discussion.\n"
+    "Anyone Who Loves a Good Pint: If you're looking for a place to relax, network, and enjoy a drink, The Emerald is the spot.\n\n"
+    "The Emerald is conveniently located near the conference hotel. It's within walking distance, making it easy to pop in between sessions or after a long day at the conference.\n\n"
+    "How to Participate\n\n"
+    "Show Up: no registration required. Just walk in and join the fun.\n"
+    "Spread the Word: share this information with fellow attendees and encourage them to join.\n"
+    "Contribute: if you have something to share—whether it's a project, topic for discussion, or just a good story—feel free to contribute."
+)
 
 NO_BOOT = "--no-boot" in sys.argv
 
@@ -513,6 +551,16 @@ def greeting_loop(iface: SerialInterface) -> None:
             send_chunked_text(msg, ch, iface, channel=True)
 
 
+def reminder_loop(iface: SerialInterface) -> None:
+    while True:
+        delay = REMINDER_INTERVAL + random.uniform(-REMINDER_JITTER, REMINDER_JITTER)
+        time.sleep(max(0, delay))
+        msg = safe_text(EVENT_REMINDER, MAX_TEXT_LEN)
+        for ch in respond_channels:
+            log_message("OUT", ch, msg, channel=True)
+            send_chunked_text(msg, ch, iface, channel=True)
+
+
 def main():
     global respond_channels
 
@@ -562,6 +610,7 @@ def main():
             log_message("OUT", ch, BOOT_MESSAGE, channel=True)
             send_chunked_text(BOOT_MESSAGE, ch, iface, channel=True)
     threading.Thread(target=greeting_loop, args=(iface,), daemon=True).start()
+    threading.Thread(target=reminder_loop, args=(iface,), daemon=True).start()
 
     try:
         while True:


### PR DESCRIPTION
## Summary
- log all debug output to daily files alongside conversation logs
- periodically send an EmeraldCon 2025 afterparty reminder to joined channels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a092f8b7bc8328a13b9ea7166cb89b