### PR TITLE
Set EmeraldCon reminder interval to two hours

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -127,7 +127,7 @@ HANDLE_RE = re.compile(rf"\b{re.escape(HANDLE)}\b", re.IGNORECASE)
 GREET_INTERVAL = 4 * 3600
 GREET_JITTER = 900
 
-REMINDER_INTERVAL = 6 * 3600
+REMINDER_INTERVAL = 2 * 3600
 REMINDER_JITTER = 900
 EVENT_REMINDER = (
     "Reminder for tonight - EmeraldCon 2025\n"


### PR DESCRIPTION
## Summary
- Send EmeraldCon reminder messages every two hours instead of six

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09918aeac8328a0bec049eed8905d