### PR TITLE
Redact sensitive text from logs

### DIFF
--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -24,6 +24,7 @@ from weather import get_weather
 from bbs import handle_bbs, bbs_posts
 from zork import handle_zork
 from utils.text import MAX_TEXT_LEN, MAX_LOC_LEN, safe_text, strip_llm_artifacts
+from utils import redact_sensitive
 
 LOG_DIR = "logs"
 os.makedirs(LOG_DIR, exist_ok=True, mode=0o700)
@@ -188,7 +189,7 @@ executor = BoundedExecutor(MAX_WORKERS, MAX_QUEUE_SIZE)
 respond_channels: set[int] = set()
 
 def log_message(direction: str, target: int, message: str, channel: bool = False):
-    message = safe_text(message, MAX_TEXT_LEN)
+    message = redact_sensitive(safe_text(message, MAX_TEXT_LEN))
     date_str = datetime.date.today().isoformat()
     logfile = os.path.join(LOG_DIR, f"{date_str}.log")
     with open(logfile, "a", encoding="utf-8") as f:
@@ -508,7 +509,7 @@ def on_receive(
             channel,
             to,
             pkt.get("from"),
-            text,
+            redact_sensitive(text),
         )
         if not text:
             logger.debug("no text; ignoring packet")

--- a/tests/test_redact_logging.py
+++ b/tests/test_redact_logging.py
@@ -1,0 +1,43 @@
+import datetime
+import logging
+from types import SimpleNamespace
+
+import meshtastic_llm_bot as bot
+
+
+class DummyIface:
+    myInfo = SimpleNamespace(my_node_num=1)
+
+
+def test_log_message_redacts_sensitive(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot, "LOG_DIR", str(tmp_path))
+    text = "psk=abcd password=secret hello"
+    bot.log_message("IN", 1, text)
+    logfile = tmp_path / f"{datetime.date.today().isoformat()}.log"
+    data = logfile.read_text()
+    assert "secret" not in data
+    assert "abcd" not in data
+    assert "hello" not in data
+    assert "[REDACTED]" in data
+
+
+def test_on_receive_debug_redacts_sensitive(monkeypatch, caplog):
+    monkeypatch.setattr(bot, "log_message", lambda *a, **k: None)
+    monkeypatch.setattr(bot, "respond_channels", {0})
+    monkeypatch.setattr(bot, "is_addressed", lambda *a, **k: True)
+    monkeypatch.setattr(bot, "mark_addressed", lambda *a, **k: None)
+
+    class DummyFuture:
+        def add_done_callback(self, fn):
+            pass
+
+    monkeypatch.setattr(bot.executor, "submit", lambda *a, **k: DummyFuture())
+
+    packet = {"decoded": {"text": "password=foo psk=bar secret"}, "channel": 0, "to": 1, "from": 2}
+    caplog.set_level(logging.DEBUG)
+    bot.on_receive(packet=packet, interface=DummyIface())
+    logs = "\n".join(caplog.messages)
+    assert "foo" not in logs
+    assert "bar" not in logs
+    assert "secret" not in logs
+    assert "[REDACTED]" in logs

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,41 @@
 # Utility modules for meshtastic LLM project
 
+from __future__ import annotations
+
+import re
+
+
+_REDACT_PATTERNS = [
+    re.compile(r"(?i)password=[^\s&]+"),
+    re.compile(r"(?i)psk=[^\s&]+"),
+    re.compile(r"(?i)message=[^\s&]+"),
+]
+
+
+def redact_sensitive(text: str) -> str:
+    """Mask potentially sensitive text before logging.
+
+    Replaces common credential patterns such as ``password=`` and ``psk`` with a
+    ``[REDACTED]`` marker and suppresses any message content entirely.
+
+    Parameters
+    ----------
+    text: str
+        The text to sanitize.
+
+    Returns
+    -------
+    str
+        A redacted version of *text* safe for logging.
+    """
+
+    if not text:
+        return text
+
+    redacted = text
+    for pat in _REDACT_PATTERNS:
+        redacted = pat.sub(lambda m: m.group(0).split("=")[0] + "=[REDACTED]", redacted)
+
+    # Never log actual message content
+    return "[REDACTED]"
+


### PR DESCRIPTION
## Summary
- introduce `utils.redact_sensitive` to mask credential patterns and all message content
- apply redaction in `log_message` and `on_receive` debug output
- add tests ensuring logs never expose raw credentials or message text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0da8938f8832884310c4a8e5bd064