### PR TITLE
Use module-level logger with configurable debug flag

### DIFF
--- a/bbs.py
+++ b/bbs.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 
 from utils.text import MAX_TEXT_LEN, safe_text
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("meshtastic_llm_bot")
 BBS_DIR = os.path.abspath(os.getenv("MESHTASTIC_BBS_DIR", "bbs_data"))
 os.makedirs(BBS_DIR, exist_ok=True, mode=0o700)
 try:

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -32,7 +32,7 @@ os.makedirs(LOG_DIR, exist_ok=True, mode=0o700)
 _date_str = datetime.date.today().isoformat()
 _debug_logfile = os.path.join(LOG_DIR, f"{_date_str}-debug.log")
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
     handlers=[
         logging.FileHandler(_debug_logfile, encoding="utf-8"),
@@ -44,7 +44,15 @@ try:
 except OSError:
     pass
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("meshtastic_llm_bot")
+logger.propagate = False
+for handler in logging.getLogger().handlers:
+    logger.addHandler(handler)
+
+if os.getenv("MESHTASTIC_DEBUG"):
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
 
 SOULS_DIR = Path("souls")
 

--- a/tests/test_bbs_failures.py
+++ b/tests/test_bbs_failures.py
@@ -24,21 +24,21 @@ class SaveBoardFailureTests(unittest.TestCase):
 
     def test_json_dump_failure_removes_temp_and_logs(self):
         with patch("bbs.json.dump", side_effect=OSError("fail")):
-            with self.assertLogs("bbs", level="ERROR") as cm:
+            with self.assertLogs("meshtastic_llm_bot", level="ERROR") as cm:
                 bbs._save_board(1, ["post"])
             self.assertTrue(any("Failed to write board" in m for m in cm.output))
         self.assertEqual(os.listdir(BBS_DIR), [])
 
     def test_replace_failure_removes_temp_and_logs(self):
         with patch("bbs.os.replace", side_effect=OSError("fail")):
-            with self.assertLogs("bbs", level="ERROR") as cm:
+            with self.assertLogs("meshtastic_llm_bot", level="ERROR") as cm:
                 bbs._save_board(1, ["post"])
             self.assertTrue(any("Failed to replace" in m for m in cm.output))
         self.assertEqual(os.listdir(BBS_DIR), [])
 
     def test_chmod_failure_logs(self):
         with patch("bbs.os.chmod", side_effect=OSError("fail")):
-            with self.assertLogs("bbs", level="ERROR") as cm:
+            with self.assertLogs("meshtastic_llm_bot", level="ERROR") as cm:
                 bbs._save_board(1, ["post"])
             self.assertTrue(any("Failed to chmod" in m for m in cm.output))
         board_path = os.path.join(BBS_DIR, "1.json")

--- a/tests/test_redact_logging.py
+++ b/tests/test_redact_logging.py
@@ -1,13 +1,28 @@
 import datetime
 import logging
+import sys
+import types
 from types import SimpleNamespace
+
+meshtastic_stub = types.ModuleType("meshtastic")
+serial_stub = types.ModuleType("serial_interface")
+
+class DummySerial:
+    pass
+
+serial_stub.SerialInterface = DummySerial
+meshtastic_stub.serial_interface = serial_stub
+sys.modules.setdefault("meshtastic", meshtastic_stub)
+sys.modules.setdefault("meshtastic.serial_interface", serial_stub)
+
+pubsub_stub = types.ModuleType("pubsub")
+pubsub_stub.pub = SimpleNamespace(subscribe=lambda *a, **k: None)
+sys.modules.setdefault("pubsub", pubsub_stub)
 
 import meshtastic_llm_bot as bot
 
-
 class DummyIface:
     myInfo = SimpleNamespace(my_node_num=1)
-
 
 def test_log_message_redacts_sensitive(tmp_path, monkeypatch):
     monkeypatch.setattr(bot, "LOG_DIR", str(tmp_path))
@@ -20,8 +35,10 @@ def test_log_message_redacts_sensitive(tmp_path, monkeypatch):
     assert "hello" not in data
     assert "[REDACTED]" in data
 
-
 def test_on_receive_debug_redacts_sensitive(monkeypatch, caplog):
+    monkeypatch.setenv("MESHTASTIC_DEBUG", "1")
+    bot.logger.setLevel(logging.DEBUG)
+
     monkeypatch.setattr(bot, "log_message", lambda *a, **k: None)
     monkeypatch.setattr(bot, "respond_channels", {0})
     monkeypatch.setattr(bot, "is_addressed", lambda *a, **k: True)
@@ -34,7 +51,7 @@ def test_on_receive_debug_redacts_sensitive(monkeypatch, caplog):
     monkeypatch.setattr(bot.executor, "submit", lambda *a, **k: DummyFuture())
 
     packet = {"decoded": {"text": "password=foo psk=bar secret"}, "channel": 0, "to": 1, "from": 2}
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger="meshtastic_llm_bot")
     bot.on_receive(packet=packet, interface=DummyIface())
     logs = "\n".join(caplog.messages)
     assert "foo" not in logs


### PR DESCRIPTION
## Summary
- switch default logging to INFO and centralize logger as "meshtastic_llm_bot"
- allow re-enabling DEBUG logging via the MESHTASTIC_DEBUG environment variable
- update tests for new logger configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0db9e32c48328ada4e6e58d862f20