### PR TITLE
refactor: generalize bot env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The game loads a 30-room world from JSON data, supports standard adventure comma
    `MESHTASTIC_MODEL_NAME` to override the LM Studio API base URL, API key, and
    model name. They default to `http://localhost:1234/v1`, `lm-studio`, and
    `mradermacher/WizardLM-1.0-Uncensored-Llama2-13b-GGUF` respectively.
+ - Define `BOT_CLI_TOKEN` with a shared secret to require an auth token on
+   startup.
+ - Use `BOT_CHANNELS` to preselect the channel(s) (0–4 or `all`) for replies
+   without an interactive prompt.
  - Modify `CHUNK_BYTES`, `CHANNEL_CHUNK_BYTES`, or the `DELAY_MIN`/`DELAY_MAX`
    values to fit your setup or preferences.
  - `MAX_HISTORY_LEN` controls how many messages per peer are kept in memory.

--- a/meshtastic_llm_bot.py
+++ b/meshtastic_llm_bot.py
@@ -608,17 +608,17 @@ def reminder_loop(iface: SerialInterface) -> None:
 def main():
     global respond_channels
     check_api_key()
-    token_env = os.getenv("CIPHER_CLI_TOKEN")
+    token_env = os.getenv("BOT_CLI_TOKEN")
     if token_env:
         user_token = getpass.getpass("CLI auth token: ")
         if not hmac.compare_digest(user_token, token_env):
             print("Invalid auth token.")
             return
 
-    selection_env = os.getenv("CIPHER_CHANNELS")
+    selection_env = os.getenv("BOT_CHANNELS")
     if selection_env is None:
         selection = input("Respond on channel 0, 1, 2, 3, 4, or 'all'? ").strip().lower()
-        os.environ["CIPHER_CHANNELS"] = selection
+        os.environ["BOT_CHANNELS"] = selection
     else:
         selection = selection_env.strip().lower()
     if selection == "all":
@@ -642,9 +642,9 @@ def main():
     pub.subscribe(on_receive, "meshtastic.receive.text")
     if respond_channels:
         chs = ", ".join(str(c) for c in sorted(respond_channels))
-        print(f"Meshtastic ↔️ Cipher ready. DMs or channel(s) {chs}")
+        print(f"Meshtastic ↔️ {SOUL_NAME} ready. DMs or channel(s) {chs}")
     else:
-        print("Meshtastic ↔️ Cipher ready. DMs only")
+        print(f"Meshtastic ↔️ {SOUL_NAME} ready. DMs only")
     if not NO_BOOT:
         print(BOOT_MESSAGE)
         for ch in respond_channels:


### PR DESCRIPTION
## Summary
- replace hard-coded `Cipher` banner with soul name
- rename `CIPHER_*` env vars to `BOT_CLI_TOKEN` and `BOT_CHANNELS`
- document new environment variables in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33c44ea1083289a1fe6b40e2c743b